### PR TITLE
Wrap arithmetic expression in parentheses

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,7 +21,7 @@ class DatabaseSeeder extends Seeder
         ]);
 
         User::factory(99)
-            ->sequence(fn ($sequence) => ['name' => 'Person '.$sequence->index + 2])
+            ->sequence(fn ($sequence) => ['name' => 'Person'.($sequence->index + 2)])
             ->create();
 
         foreach (range(1, 20) as $user_id) {


### PR DESCRIPTION
- While running the repo on localhost I bumped into this error: 
`The behavior of unparenthesized expressions containing both '.' and '+'/'-' will change in PHP 8: '+'/'-' will take a higher`
- After searching online I came across this StackOverflow thread :
[StackOver flow  thead](https://stackoverflow.com/questions/67819276/the-behavior-of-unparenthesized-expressions-containing-both-and-will)
- The breaking in the localhost when running `php artisan db:seed` happened because of an update in Laravel